### PR TITLE
Started deprecation of autoEscalate functionality

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -2,11 +2,6 @@
 <project version="4">
   <component name="RemoteRepositoriesConfiguration">
     <remote-repository>
-      <option name="id" value="maven-snapshots" />
-      <option name="name" value="Sonatype OSS Snapshots" />
-      <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots/" />
-    </remote-repository>
-    <remote-repository>
       <option name="id" value="jCenter" />
       <option name="name" value="jCenter" />
       <option name="url" value="http://jcenter.bintray.com" />
@@ -17,14 +12,29 @@
       <option name="url" value="https://repo.maven.apache.org/maven2" />
     </remote-repository>
     <remote-repository>
+      <option name="id" value="jCenter" />
+      <option name="name" value="jCenter" />
+      <option name="url" value="https://jcenter.bintray.com" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="adaptavist-external" />
+      <option name="name" value="adaptavist-external" />
+      <option name="url" value="https://nexus.adaptavist.com/content/repositories/external" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven-snapshots" />
+      <option name="name" value="Sonatype OSS Snapshots" />
+      <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots/" />
+    </remote-repository>
+    <remote-repository>
       <option name="id" value="central" />
       <option name="name" value="Maven Central repository" />
       <option name="url" value="https://repo1.maven.org/maven2" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="jCenter" />
-      <option name="name" value="jCenter" />
-      <option name="url" value="https://jcenter.bintray.com" />
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="atlassian-public" />
@@ -35,16 +45,6 @@
       <option name="id" value="riada-repository" />
       <option name="name" value="riada-repository" />
       <option name="url" value="https://repo.riada.io/repository/riada-repo/" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="jboss.community" />
-      <option name="name" value="JBoss Community repository" />
-      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="adaptavist-external" />
-      <option name="name" value="adaptavist-external" />
-      <option name="url" value="https://nexus.adaptavist.com/content/repositories/external" />
     </remote-repository>
   </component>
 </project>

--- a/InsightManager.iml
+++ b/InsightManager.iml
@@ -12,24 +12,10 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="groovy-2.5.8" level="application" />
-    <orderEntry type="library" name="Maven: com.riadalabs.jira.plugins:insight:8.6.5" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-index:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-utils:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-model:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-persistence:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-services:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-external-services:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-iql:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-api-graphql:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: com.riadalabs.jira.plugins:insight:8.6.5" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-index:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-utils:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-model:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-persistence:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-services:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-external-services:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-core-iql:1.0.39" level="project" />
-    <orderEntry type="library" name="Maven: io.riada:insight-api-graphql:1.0.39" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.sal:sal-api:3.0.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.onresolve.jira.groovy:groovyrunner:6.2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-beans:4.1.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: io.github.classgraph:classgraph:4.8.43" level="project" />
     <orderEntry type="library" name="Maven: com.riadalabs.jira.plugins:insight:8.6.5" level="project" />
     <orderEntry type="library" name="Maven: javax.annotation:javax.annotation-api:1.3.2" level="project" />
     <orderEntry type="library" name="Maven: com.sun.activation:javax.activation:1.2.0" level="project" />
@@ -115,9 +101,9 @@
     <orderEntry type="library" name="Maven: io.riada.jira.plugins:insight-core-widget-ui:2.0.6" level="project" />
     <orderEntry type="library" name="Maven: com.cronutils:cron-utils:9.0.1" level="project" />
     <orderEntry type="library" name="Maven: net.redhogs.cronparser:cron-parser-core:3.5" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.sal:sal-api:3.0.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.sal:sal-api:4.0.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.plugins:atlassian-plugins-osgi-bridge:5.3.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.onresolve.jira.groovy:groovyrunner:6.2.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.onresolve.jira.groovy:groovyrunner:6.9.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.jira:jira-api:8.6.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.annotations:atlassian-annotations:2.1.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.ofbiz:entityengine-share:1.4.0" level="project" />
@@ -431,7 +417,7 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.jira.compat:jira-cross-compatibility-lib-bridge-api:0.47" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.jira.compat:jira-cross-compatibility-lib-bridge-63:0.47" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.jira.compat:jira-cross-compatibility-lib-bridge-70:0.47" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-beans:4.1.7.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.springframework:spring-beans:5.0.10.RELEASE" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.groovy:groovy:2.5.11" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.groovy:groovy-ant:2.5.11" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.ant:ant:1.9.13" level="project" />
@@ -473,7 +459,7 @@
     <orderEntry type="library" scope="TEST" name="Maven: net.sf.ezmorph:ezmorph:1.0.6" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.sourceforge.nekohtml:nekohtml:1.9.16" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: xml-resolver:xml-resolver:1.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: io.github.classgraph:classgraph:4.8.43" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: io.github.classgraph:classgraph:4.8.71" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.spockframework:spock-core:1.2-groovy-2.5" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ IM is built to be as user friendly and flexible as possible. If you are comforta
 
 IM can be used anywhere ScriptRunner executes groovy scripts, for example workflow transitions, behaviors and REST endpoints. The second release of IM will also support being run by Insight own groovy capabilities. 
 
-InsightManager was initially created by Riada AB which is a partner to Mindville who are the creators of Insight. 
+InsightManager was initially created by Riada AB which at the time was a partner to Mindville who are the creators of Insight. 
 InsightManager is still maintained by Riada AB but welcomes any and all inputs and pull requests. 
 InsightManager is provided “as is” without warranty of any kind, it is to be used at your own risk and always tested in a non production environment first.
 
+“THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.”
 
 
 ## Some quick examples to grab your attention

--- a/Tests/customRiadaLibraries/insightmanager/InsightManagerForScriptRunnerSpecV2.groovy
+++ b/Tests/customRiadaLibraries/insightmanager/InsightManagerForScriptRunnerSpecV2.groovy
@@ -76,12 +76,18 @@ return
 
 JUnitCore jUnitCore = new JUnitCore()
 
-Result spockResult = jUnitCore.run(Request.method(InsightManagerForScriptRunnerSpecificationsV2.class, "Test Object comment CRD operations"))
+//Result spockResult = jUnitCore.run(Request.method(InsightManagerForScriptRunnerSpecificationsV2.class, "Test Object comment CRD operations"))
 //Result spockResult = jUnitCore.run(Request.method(InsightManagerForScriptRunnerSpecificationsV2.class, "Test updateObjectAttributes and updateObjectAttribute with various attribute types"))
-//Result spockResult = jUnitCore.run(InsightManagerForScriptRunnerSpecificationsV2)
+Result spockResult = jUnitCore.run(InsightManagerForScriptRunnerSpecificationsV2)
 
 
-spockResult.failures.each { log.error(it) }
+spockResult.failures.each {
+    log.error(it)
+    log.error(it.description)
+    log.error(it.message)
+    log.error(it.testHeader)
+    log.error(it.trace)
+}
 
 spockResult.each { log.info("Result:" + it.toString()) }
 
@@ -1026,7 +1032,7 @@ class InsightManagerForScriptRunnerSpecificationsV2 extends Specification {
 
 
         //This is confirmed to fail in Insight 8.6.12, the Insight API ignores supplied authors.
-        /*
+        /* https://jira.mindville.com/browse/ICS-1879
         then: "It should be authored by the schema manager"
         unrestrictedCommentBean.author == specHelper.insightSchemaManager.key
          */
@@ -1045,8 +1051,8 @@ class InsightManagerForScriptRunnerSpecificationsV2 extends Specification {
         log.debug("\t"*2 + (im.getObjectComments(newObject).findAll{it.comment == managerAccessCommentText}.size() == 1))
 
 
-        //This is confirmed to fail in Inishgt 8.6.12, the Insight API will let users view restricted comments.
-        /*
+        //This is confirmed to fail in Insight 8.6.12, the Insight API will let users view restricted comments.
+        /* https://jira.mindville.com/browse/ICS-1860
         then: "It should not be readable by schema user"
         log.debug("\tIt not should be readable by schema user")
         im.setServiceAccount(specHelper.insightSchemaUser)
@@ -1153,6 +1159,7 @@ class SpecHelper {
                         projectCustomer: "CustomerName"
                 ]
         ]
+
         boolean fileCreated = settingsFile.createNewFile()
 
         if (fileCreated) {

--- a/src/customRiadaLibraries/insightmanager/SimplifiedAttachmentBean.groovy
+++ b/src/customRiadaLibraries/insightmanager/SimplifiedAttachmentBean.groovy
@@ -4,6 +4,8 @@ import com.atlassian.jira.component.ComponentAccessor
 import com.atlassian.jira.config.util.JiraHome
 import com.riadalabs.jira.plugins.insight.services.model.AttachmentBean
 
+//TODO update documentation linking to this file
+
 /**
  * <h3>This is a class intended to simplify working with Insight AttachmentBeans</h3>
  * Once instantiated it will give you easy access to the AttachmentBean it self as well as the related File object


### PR DESCRIPTION
- Started deprecation of autoEscalate functionality
  - So far no breaking changes.
- Improved documentation
- Removed startup checks of Insight app version.
  - This wasn't well implemented to begin with. 
  - This change leaves it up to the user to make sure they are using a compatible Insight version.  
- Updated comments in the SpecV2 tests with links to Insight bugs.