### PR TITLE
Fix for clearObjectAttribute() and already empty attribute values

### DIFF
--- a/src/customRiadaLibraries/insightmanager/InsightManagerForScriptrunner.groovy
+++ b/src/customRiadaLibraries/insightmanager/InsightManagerForScriptrunner.groovy
@@ -539,8 +539,8 @@ class InsightManagerForScriptrunner {
 
             try {
                 escalatePrivilage("\t")
-                long attributeBeanId = objectFacade.loadObjectAttributeBean(objectBean.id, attribute).id
-                if (attributeBeanId != null) {
+                Long attributeBeanId = objectFacade.loadObjectAttributeBean(objectBean.id, attribute)?.id
+                if (attributeBeanId) {
 
                     objectFacade.deleteObjectAttributeBean(attributeBeanId, this.eventDispatchOption)
 


### PR DESCRIPTION
The current clearObjectAttribute() method fails if the object attribute already is empty.